### PR TITLE
[HBT-012] Wire all dead/placeholder UI buttons

### DIFF
--- a/HABITOS_EXECUTION_LEDGER.md
+++ b/HABITOS_EXECUTION_LEDGER.md
@@ -1,6 +1,6 @@
 # HabitOS Execution Ledger
 
-Last updated: 2026-03-07 18:44:14 CET
+Last updated: 2026-03-08 18:05:00 CET
 
 ## Purpose
 
@@ -49,12 +49,14 @@ Every Copilot or AI agent working in this repository must use this file as the s
 | HBT-008 | TODO | Medium | Testing | Repair the testing baseline, verify unit test target contents, and establish at least a minimal trustworthy regression suite. | 2026-03-07 18:33:46 CET |  | Test coverage appears weak and one visible test file looked anomalous. |
 | HBT-009 | DONE | High | Project Governance | Create persistent Copilot operating rules, configuration guidance, and a mandatory execution ledger for future sessions. | 2026-03-07 18:33:46 CET | 2026-03-07 18:36:50 CET | Created `HABITOS_EXECUTION_LEDGER.md`, `.github/copilot-instructions.md`, `COPILOT_SETUP_HABITOS.md`, and updated `HABITOS_PROJECT_INTELLIGENCE_REPORT.html`. |
 | HBT-010 | DONE | High | Project Governance | Create a direct handoff document for the next Copilot and require future agents to keep the handoff/context documents updated so switching agents stays seamless. | 2026-03-07 18:43:22 CET | 2026-03-07 18:44:14 CET | Created `NEXT_COPILOT_HANDOFF.md` and updated `.github/copilot-instructions.md`, `COPILOT_SETUP_HABITOS.md`, and `HABITOS_PROJECT_INTELLIGENCE_REPORT.html` so future agents keep the shared context current. |
+| HBT-012 | DONE | High | UI Wiring | Wire all dead/placeholder UI buttons found during user testing: FAB actions, chat send, quick replies, "Ir al chat", "Ver receta", "Ya comí", "Registrar peso", shopping list, Privacidad, Ayuda, and fix logout bug. | 2026-03-08 17:00:00 CET | 2026-03-08 18:05:00 CET | 8 files changed across Views, Core, ContentView, and SettingsViewModel. Issue #17, PR #18, commit `53bfc4b`. |
 
 ## Session Change Log
 
 Use this section to append one flat entry per completed task. Newest entries first.
 
 - 2026-03-07 18:36:50 CET | HBT-009 | Created the persistent Copilot workflow base, including mandatory ledger rules, setup documentation, and report integration. | Files: `HABITOS_EXECUTION_LEDGER.md`, `.github/copilot-instructions.md`, `COPILOT_SETUP_HABITOS.md`, `HABITOS_PROJECT_INTELLIGENCE_REPORT.html`
+- 2026-03-08 18:05:00 CET | HBT-012 | Wired all dead/placeholder UI buttons: FAB actions → sheets, chat send + quick replies → demo auto-reply, Ir al chat → tab switch, Ver receta → diet tab, Ya comí → MealLogView, Registrar peso → WeightLogView, shopping list NavigationLink fix, Privacidad/Ayuda → placeholder views, logout bug fix (appState.signOut always runs). | Files: `ContentView.swift`, `Components.swift`, `SettingsViewModel.swift`, `ChatView.swift`, `DashboardHomeView.swift`, `MealPlanView.swift`, `ProfileView.swift`, `ProgressChartView.swift`
 - 2026-03-07 18:44:14 CET | HBT-010 | Added a direct takeover brief for the next Copilot and required future sessions to maintain the shared context documents. | Files: `NEXT_COPILOT_HANDOFF.md`, `.github/copilot-instructions.md`, `COPILOT_SETUP_HABITOS.md`, `HABITOS_PROJECT_INTELLIGENCE_REPORT.html`
 
 ## Update Protocol

--- a/NEXT_COPILOT_HANDOFF.md
+++ b/NEXT_COPILOT_HANDOFF.md
@@ -87,11 +87,16 @@ If the user simply says to continue, your default sequence is:
 
 At the time of this handoff, the likely top-value areas are:
 
-- removing root-shell dependence on `HabitOSDataService`
-- converging duplicated models
-- verifying and closing the real iPhone magic-link flow
-- confirming the real Supabase schema for coach memory
-- strengthening the testing baseline
+- removing root-shell dependence on `HabitOSDataService` (HBT-001, PR #4 pending merge)
+- converging duplicated models (HBT-002, PR #4 pending merge)
+- verifying and closing the real iPhone magic-link flow (HBT-003, PR #6 pending merge)
+- confirming the real Supabase schema for coach memory (HBT-004, PR #6 pending merge)
+- strengthening the testing baseline (HBT-008, PR #12 pending merge)
+- merging the 8 open PRs (#4, #6, #8, #10, #12, #14, #16, #18) to develop in sequence
+- replacing the demo chat auto-reply in ContentView with real ChatViewModel + Supabase once model convergence (HBT-002) is merged
+- the day selector in MealPlanView works but shows all meals flat (not per-day) — needs per-day filtering once NutritionPlan model is adopted
+- profile avatar photo editing (not yet wired, deferred)
+- progress time period filtering (buttons animate but don't filter chart data, deferred)
 
 ## Final Requirement
 

--- a/habitOS-mobile/ContentView.swift
+++ b/habitOS-mobile/ContentView.swift
@@ -92,7 +92,9 @@ struct ContentView: View {
                 waterTarget: viewModel.waterTarget,
                 health: viewModel.health,
                 onToggleTask: { viewModel.toggleDailyTask($0) },
-                onAddWater: { viewModel.addWater($0) }
+                onAddWater: { viewModel.addWater($0) },
+                onGoToChat: { selectedTab = 2 },
+                onGoToDiet: { selectedTab = 1 }
             )
             .toolbarBackground(Color.hbVanilla.opacity(0.95), for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
@@ -117,7 +119,22 @@ struct ContentView: View {
         NavigationStack {
             ChatView(
                 messages: viewModel.chatMessages,
-                coachName: viewModel.user?.coachName ?? "Coach"
+                coachName: viewModel.user?.coachName ?? "Coach",
+                onSend: { text in
+                    // Add user message
+                    let userMsg = ChatMessage(id: UUID(), role: .user, text: text, timestamp: Date())
+                    viewModel.chatMessages.append(userMsg)
+                    // Demo auto-reply
+                    Task {
+                        try? await Task.sleep(for: .milliseconds(1200))
+                        let reply = ChatMessage(
+                            id: UUID(), role: .coach,
+                            text: demoReply(for: text),
+                            timestamp: Date()
+                        )
+                        viewModel.chatMessages.append(reply)
+                    }
+                }
             )
             .navigationTitle(viewModel.user?.coachName ?? "Chat")
             .navigationBarTitleDisplayMode(.inline)
@@ -143,7 +160,10 @@ struct ContentView: View {
         NavigationStack {
             ProgressChartView(
                 streaks: viewModel.streaks,
-                weeklySummary: viewModel.weeklySummary
+                weeklySummary: viewModel.weeklySummary,
+                userId: viewModel.user?.id,
+                startWeight: viewModel.user?.currentWeightKg,
+                goalWeight: viewModel.user?.targetWeightKg
             )
             .navigationTitle("Progreso")
             .navigationBarTitleDisplayMode(.inline)
@@ -173,6 +193,21 @@ struct ContentView: View {
         }
     }
 
+    // MARK: – Demo Chat Replies
+    private func demoReply(for text: String) -> String {
+        let lower = text.lowercased()
+        if lower.contains("plan") || lower.contains("seguí") {
+            return "¡Genial! Seguir el plan es lo más importante. Sigue así 💪"
+        } else if lower.contains("hambre") {
+            return "Es normal tener algo de hambre entre comidas. Prueba beber agua o tomar un snack ligero como frutos secos."
+        } else if lower.contains("no pude") {
+            return "No pasa nada, un día no define tu progreso. Mañana volvemos con todo 🙌"
+        } else if lower.contains("duda") {
+            return "Claro, cuéntame. Estoy aquí para ayudarte con lo que necesites."
+        } else {
+            return "Gracias por contarme. Reviso tu progreso y te digo cómo vas esta semana."
+        }
+    }
 }
 
 // MARK: – Loading Overlay View

--- a/habitOS-mobile/Core/Components.swift
+++ b/habitOS-mobile/Core/Components.swift
@@ -193,6 +193,11 @@ struct HBGhostButton: View {
 // ═══════════════════════════════════════════════════════════════
 struct HBFloatingActionButton: View {
     @Binding var isExpanded: Bool
+    var onAction: ((FABAction) -> Void)?
+
+    enum FABAction: Int, CaseIterable {
+        case journal, mealPhoto, weightLog, scanner
+    }
 
     private let actions: [(icon: String, label: String)] = [
         ("pencil.line",        "Diario"),
@@ -205,6 +210,12 @@ struct HBFloatingActionButton: View {
         VStack(alignment: .trailing, spacing: 10) {
             if isExpanded {
                 ForEach(Array(actions.enumerated()), id: \.offset) { index, action in
+                    Button {
+                        if let fabAction = FABAction(rawValue: index) {
+                            onAction?(fabAction)
+                        }
+                        withAnimation(.spring(response: 0.25, dampingFraction: 0.75)) { isExpanded = false }
+                    } label: {
                     HStack(spacing: 10) {
                         Text(action.label)
                             .font(.system(size: 13, weight: .medium))
@@ -221,6 +232,8 @@ struct HBFloatingActionButton: View {
                             .frame(width: 40, height: 40)
                             .background(Color.hbSage, in: Circle())
                     }
+                    }
+                    .buttonStyle(.plain)
                     .transition(.asymmetric(
                         insertion: .move(edge: .trailing).combined(with: .opacity)
                             .animation(.spring(response: 0.35, dampingFraction: 0.7)

--- a/habitOS-mobile/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/habitOS-mobile/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -17,12 +17,13 @@ final class SettingsViewModel {
 
         do {
             try await AuthRepository().signOut()
-            // Reset AppState to bump back to authentication screen
-            await MainActor.run {
-                appState.signOut()
-            }
         } catch {
             print("Error logging out: \(error)")
+        }
+
+        // Always reset AppState regardless of Supabase result
+        await MainActor.run {
+            appState.signOut()
         }
     }
 }

--- a/habitOS-mobile/Views/ChatView.swift
+++ b/habitOS-mobile/Views/ChatView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ChatView: View {
     let messages: [ChatMessage]
     let coachName: String
+    var onSend: ((String) -> Void)?
 
     @State private var newMessage: String = ""
     @State private var showQuickReplies = true
@@ -39,6 +40,11 @@ struct ChatView: View {
                 .onAppear {
                     if let lastId = messages.last?.id { proxy.scrollTo(lastId, anchor: .bottom) }
                 }
+                .onChange(of: messages.count) {
+                    if let lastId = messages.last?.id {
+                        withAnimation { proxy.scrollTo(lastId, anchor: .bottom) }
+                    }
+                }
             }
 
             // Quick replies
@@ -47,7 +53,7 @@ struct ChatView: View {
                     HStack(spacing: 8) {
                         ForEach(quickReplies, id: \.self) { reply in
                             Button {
-                                newMessage = reply
+                                onSend?(reply)
                                 withAnimation { showQuickReplies = false }
                             } label: {
                                 Text(reply)
@@ -76,8 +82,13 @@ struct ChatView: View {
                     .background(Color.hbVanilla, in: RoundedRectangle(cornerRadius: HBTokens.radiusMedium))
                     .overlay(RoundedRectangle(cornerRadius: HBTokens.radiusMedium)
                         .stroke(Color.hbLine, lineWidth: 1))
+                    .onSubmit {
+                        sendCurrentMessage()
+                    }
 
-                Button {} label: {
+                Button {
+                    sendCurrentMessage()
+                } label: {
                     Image(systemName: "arrow.up")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(newMessage.isEmpty ? Color.hbMuted2 : Color.hbVanilla)
@@ -95,6 +106,13 @@ struct ChatView: View {
             .background(Color.hbPaper)
         }
         .background(Color.hbVanilla)
+    }
+
+    private func sendCurrentMessage() {
+        let text = newMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        onSend?(text)
+        newMessage = ""
     }
 
     private func messageBubble(_ message: ChatMessage) -> some View {

--- a/habitOS-mobile/Views/DashboardHomeView.swift
+++ b/habitOS-mobile/Views/DashboardHomeView.swift
@@ -15,8 +15,15 @@ struct DashboardHomeView: View {
     let health: HealthKitManager
     let onToggleTask: (DailyTask) -> Void
     let onAddWater: (Double) -> Void
+    var onGoToChat: (() -> Void)?
+    var onGoToDiet: (() -> Void)?
 
     @State private var isFABExpanded = false
+    @State private var showJournal = false
+    @State private var showMealLog = false
+    @State private var showWeightLog = false
+    @State private var showScanner = false
+    @State private var showNextMealLog = false
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
@@ -83,9 +90,39 @@ struct DashboardHomeView: View {
                     }
             }
 
-            HBFloatingActionButton(isExpanded: $isFABExpanded)
+            HBFloatingActionButton(isExpanded: $isFABExpanded) { action in
+                switch action {
+                case .journal:   if user?.id != nil { showJournal = true }
+                case .mealPhoto: showMealLog = true
+                case .weightLog: if user?.id != nil { showWeightLog = true }
+                case .scanner:   showScanner = true
+                }
+            }
                 .padding(.trailing, HBTokens.padScreen)
                 .padding(.bottom, 20)
+        }
+        .sheet(isPresented: $showJournal) {
+            if let uid = user?.id {
+                NavigationStack { JournalView(userId: uid) }
+            }
+        }
+        .sheet(isPresented: $showMealLog) {
+            NavigationStack { MealLogView(mealName: "Registro libre", mealItems: []) }
+        }
+        .sheet(isPresented: $showWeightLog) {
+            if let uid = user?.id {
+                NavigationStack {
+                    WeightLogView(userId: uid, startWeight: user?.currentWeightKg, goalWeight: user?.targetWeightKg)
+                }
+            }
+        }
+        .sheet(isPresented: $showNextMealLog) {
+            NavigationStack {
+                MealLogView(mealName: nextMeal?.mealName ?? "Comida", mealItems: nextMeal?.items ?? [])
+            }
+        }
+        .fullScreenCover(isPresented: $showScanner) {
+            BarcodeScannerView()
         }
     }
 
@@ -226,9 +263,9 @@ struct DashboardHomeView: View {
                         }
                     }
                     HStack {
-                        HBGhostButton("Ver receta", icon: "book") {}
+                        HBGhostButton("Ver receta", icon: "book") { onGoToDiet?() }
                         Spacer()
-                        HBPrimaryButton("Ya comí ✓") {}.frame(width: 130)
+                        HBPrimaryButton("Ya comí ✓") { showNextMealLog = true }.frame(width: 130)
                     }
                     .padding(.top, 4)
                 }
@@ -295,7 +332,7 @@ struct DashboardHomeView: View {
                         .foregroundStyle(Color.hbMuted)
                         .lineSpacing(4)
                         .lineLimit(3)
-                    HStack { Spacer(); HBGhostButton("Ir al chat →") {} }
+                    HStack { Spacer(); HBGhostButton("Ir al chat →") { onGoToChat?() } }
                 }
             }
         }

--- a/habitOS-mobile/Views/MealPlanView.swift
+++ b/habitOS-mobile/Views/MealPlanView.swift
@@ -107,9 +107,15 @@ struct MealPlanView: View {
                 }
 
                 NavigationLink(destination: ShoppingListView()) {
-                    HBPrimaryButton("Lista de la compra", icon: "cart") {}
+                    HStack(spacing: 8) {
+                        Image(systemName: "cart").font(.system(size: 14, weight: .medium))
+                        Text("Lista de la compra").font(.system(size: 14, weight: .semibold))
+                    }
+                    .foregroundStyle(Color.hbVanilla)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 46)
+                    .background(Color.hbSage, in: RoundedRectangle(cornerRadius: HBTokens.radiusMedium))
                 }
-                .buttonStyle(.plain)
 
                 Spacer(minLength: 32)
             }

--- a/habitOS-mobile/Views/ProfileView.swift
+++ b/habitOS-mobile/Views/ProfileView.swift
@@ -84,9 +84,13 @@ struct ProfileView: View {
                             navRowLabel(icon: "brain.head.profile", label: "Memoria del coach")
                         }
                         HBDivider(indent: 44)
-                        navRow(icon: "lock.shield", label: "Privacidad")
+                        NavigationLink(destination: placeholderView(title: "Privacidad", icon: "lock.shield", body: "Tu información está protegida. HabitOS solo comparte datos con tu coach asignado y nunca con terceros.")) {
+                            navRowLabel(icon: "lock.shield", label: "Privacidad")
+                        }
                         HBDivider(indent: 44)
-                        navRow(icon: "questionmark.circle", label: "Ayuda")
+                        NavigationLink(destination: placeholderView(title: "Ayuda", icon: "questionmark.circle", body: "¿Necesitas ayuda? Escríbele a tu coach desde el chat. También puedes contactarnos en soporte@habitos.app.")) {
+                            navRowLabel(icon: "questionmark.circle", label: "Ayuda")
+                        }
                     }
                 }
                 .staggered(index: 3)
@@ -143,6 +147,27 @@ struct ProfileView: View {
             .padding(.top, 8)
         }
         .background(Color.hbVanilla)
+    }
+
+    private func placeholderView(title: String, icon: String, body: String) -> some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                Image(systemName: icon)
+                    .font(.system(size: 40))
+                    .foregroundStyle(Color.hbSage)
+                Text(body)
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color.hbMuted)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(4)
+                    .padding(.horizontal, 32)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 60)
+        }
+        .background(Color.hbVanilla)
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
     }
 
     private func statCard(_ label: String, value: String, unit: String) -> some View {

--- a/habitOS-mobile/Views/ProgressChartView.swift
+++ b/habitOS-mobile/Views/ProgressChartView.swift
@@ -4,8 +4,12 @@ import Charts
 struct ProgressChartView: View {
     let streaks: [StreakPoint]
     let weeklySummary: WeeklySummary?
+    var userId: UUID?
+    var startWeight: Double?
+    var goalWeight: Double?
 
     @State private var selectedTimeRange = 0
+    @State private var showWeightLog = false
     private let timeRanges = ["1S", "1M", "3M", "Todo"]
 
     var body: some View {
@@ -21,13 +25,22 @@ struct ProgressChartView: View {
                 }
                 adherenceChart.staggered(index: 2)
                 streakChart.staggered(index: 3)
-                HBPrimaryButton("Registrar peso", icon: "scalemass") {}.staggered(index: 4)
+                HBPrimaryButton("Registrar peso", icon: "scalemass") {
+                    if userId != nil { showWeightLog = true }
+                }.staggered(index: 4)
                 Spacer(minLength: 32)
             }
             .padding(.horizontal, HBTokens.padScreen)
             .padding(.top, 8)
         }
         .background(Color.hbVanilla)
+        .sheet(isPresented: $showWeightLog) {
+            if let uid = userId {
+                NavigationStack {
+                    WeightLogView(userId: uid, startWeight: startWeight, goalWeight: goalWeight)
+                }
+            }
+        }
     }
 
     private func weightCard(_ s: WeeklySummary) -> some View {


### PR DESCRIPTION
Comprehensive fix for all non-functional buttons found during user testing.

**Changes:**
- Fix logout: appState.signOut() always runs regardless of Supabase error
- FAB: all 4 sub-actions tappable with sheet presentation
- Chat: send button + quick replies wired with demo auto-reply
- Dashboard: 'Ir al chat' switches tab, 'Ver receta' to diet, 'Ya comi' opens MealLogView
- Progress: 'Registrar peso' opens WeightLogView
- MealPlan: shopping list NavigationLink fixed (no inner Button)
- Profile: Privacidad/Ayuda as NavigationLink to placeholder views

Closes #17