### PR TITLE
[HBT-012] Wire all dead/placeholder UI buttons (v2)

### DIFF
--- a/habitOS-mobile/ContentView.swift
+++ b/habitOS-mobile/ContentView.swift
@@ -94,7 +94,9 @@ struct ContentView: View {
                 waterTarget: viewModel.waterTarget,
                 health: viewModel.health,
                 onToggleTask: { viewModel.toggleDailyTask($0) },
-                onAddWater: { viewModel.addWater($0) }
+                onAddWater: { viewModel.addWater($0) },
+                onGoToChat: { selectedTab = 2 },
+                onGoToDiet: { selectedTab = 1 }
             )
             .toolbarBackground(Color.hbVanilla.opacity(0.95), for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
@@ -119,7 +121,25 @@ struct ContentView: View {
         NavigationStack {
             ChatView(
                 messages: viewModel.chatMessages,
-                coachName: viewModel.coachName
+                coachName: viewModel.coachName,
+                onSend: { text in
+                    let userMsg = CoachMessage(
+                        id: UUID(), profileId: viewModel.user?.id ?? UUID(),
+                        role: .user, channel: "app", messageText: text,
+                        createdAt: Date()
+                    )
+                    viewModel.chatMessages.append(userMsg)
+                    Task {
+                        try? await Task.sleep(for: .milliseconds(1200))
+                        let reply = CoachMessage(
+                            id: UUID(), profileId: viewModel.user?.id ?? UUID(),
+                            role: .assistant, channel: "app",
+                            messageText: demoReply(for: text),
+                            createdAt: Date()
+                        )
+                        viewModel.chatMessages.append(reply)
+                    }
+                }
             )
             .navigationTitle(viewModel.coachName)
             .navigationBarTitleDisplayMode(.inline)
@@ -145,7 +165,10 @@ struct ContentView: View {
         NavigationStack {
             ProgressChartView(
                 streaks: viewModel.streaks,
-                weeklySummary: viewModel.weeklySummary
+                weeklySummary: viewModel.weeklySummary,
+                userId: viewModel.user?.id,
+                startWeight: viewModel.user?.currentWeightKg,
+                goalWeight: nil
             )
             .navigationTitle("Progreso")
             .navigationBarTitleDisplayMode(.inline)
@@ -175,6 +198,21 @@ struct ContentView: View {
         }
     }
 
+    // MARK: – Demo Chat Replies
+    private func demoReply(for text: String) -> String {
+        let lower = text.lowercased()
+        if lower.contains("plan") || lower.contains("seguí") {
+            return "¡Genial! Seguir el plan es lo más importante. Sigue así 💪"
+        } else if lower.contains("hambre") {
+            return "Es normal tener algo de hambre entre comidas. Prueba beber agua o tomar un snack ligero como frutos secos."
+        } else if lower.contains("no pude") {
+            return "No pasa nada, un día no define tu progreso. Mañana volvemos con todo 🙌"
+        } else if lower.contains("duda") {
+            return "Claro, cuéntame. Estoy aquí para ayudarte con lo que necesites."
+        } else {
+            return "Gracias por contarme. Reviso tu progreso y te digo cómo vas esta semana."
+        }
+    }
 }
 
 // MARK: – Loading Overlay View

--- a/habitOS-mobile/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/habitOS-mobile/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -17,12 +17,13 @@ final class SettingsViewModel {
 
         do {
             try await AuthRepository().signOut()
-            // Reset AppState to bump back to authentication screen
-            await MainActor.run {
-                appState.signOut()
-            }
         } catch {
             print("Error logging out: \(error)")
+        }
+
+        // Always reset AppState regardless of Supabase result
+        await MainActor.run {
+            appState.signOut()
         }
     }
 }

--- a/habitOS-mobile/Views/ChatView.swift
+++ b/habitOS-mobile/Views/ChatView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ChatView: View {
     let messages: [CoachMessage]
     let coachName: String
+    var onSend: ((String) -> Void)?
 
     @State private var newMessage: String = ""
     @State private var showQuickReplies = true
@@ -39,6 +40,11 @@ struct ChatView: View {
                 .onAppear {
                     if let lastId = messages.last?.id { proxy.scrollTo(lastId, anchor: .bottom) }
                 }
+                .onChange(of: messages.count) {
+                    if let lastId = messages.last?.id {
+                        withAnimation { proxy.scrollTo(lastId, anchor: .bottom) }
+                    }
+                }
             }
 
             // Quick replies
@@ -47,7 +53,7 @@ struct ChatView: View {
                     HStack(spacing: 8) {
                         ForEach(quickReplies, id: \.self) { reply in
                             Button {
-                                newMessage = reply
+                                onSend?(reply)
                                 withAnimation { showQuickReplies = false }
                             } label: {
                                 Text(reply)
@@ -76,8 +82,13 @@ struct ChatView: View {
                     .background(Color.hbVanilla, in: RoundedRectangle(cornerRadius: HBTokens.radiusMedium))
                     .overlay(RoundedRectangle(cornerRadius: HBTokens.radiusMedium)
                         .stroke(Color.hbLine, lineWidth: 1))
+                    .onSubmit {
+                        sendCurrentMessage()
+                    }
 
-                Button {} label: {
+                Button {
+                    sendCurrentMessage()
+                } label: {
                     Image(systemName: "arrow.up")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(newMessage.isEmpty ? Color.hbMuted2 : Color.hbVanilla)
@@ -95,6 +106,13 @@ struct ChatView: View {
             .background(Color.hbPaper)
         }
         .background(Color.hbVanilla)
+    }
+
+    private func sendCurrentMessage() {
+        let text = newMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        onSend?(text)
+        newMessage = ""
     }
 
     private func messageBubble(_ message: CoachMessage) -> some View {

--- a/habitOS-mobile/Views/DashboardHomeView.swift
+++ b/habitOS-mobile/Views/DashboardHomeView.swift
@@ -16,12 +16,15 @@ struct DashboardHomeView: View {
     let health: HealthKitManager
     let onToggleTask: (DailyTaskItem) -> Void
     let onAddWater: (Double) -> Void
+    var onGoToChat: (() -> Void)?
+    var onGoToDiet: (() -> Void)?
 
     @State private var isFABExpanded = false
     @State private var showJournal = false
     @State private var showMealLog = false
     @State private var showWeightLog = false
     @State private var showScanner = false
+    @State private var showNextMealLog = false
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
@@ -109,7 +112,14 @@ struct DashboardHomeView: View {
         }
         .sheet(isPresented: $showWeightLog) {
             if let uid = user?.id {
-                NavigationStack { WeightLogView(userId: uid) }
+                NavigationStack {
+                    WeightLogView(userId: uid, startWeight: user?.currentWeightKg, goalWeight: nil)
+                }
+            }
+        }
+        .sheet(isPresented: $showNextMealLog) {
+            NavigationStack {
+                MealLogView(mealName: nextMeal?.mealName ?? "Comida", mealItems: nextMeal?.items ?? [])
             }
         }
         .fullScreenCover(isPresented: $showScanner) {
@@ -254,9 +264,9 @@ struct DashboardHomeView: View {
                         }
                     }
                     HStack {
-                        HBGhostButton("Ver receta", icon: "book") {}
+                        HBGhostButton("Ver receta", icon: "book") { onGoToDiet?() }
                         Spacer()
-                        HBPrimaryButton("Ya comí ✓") {}.frame(width: 130)
+                        HBPrimaryButton("Ya comí ✓") { showNextMealLog = true }.frame(width: 130)
                     }
                     .padding(.top, 4)
                 }
@@ -323,7 +333,7 @@ struct DashboardHomeView: View {
                         .foregroundStyle(Color.hbMuted)
                         .lineSpacing(4)
                         .lineLimit(3)
-                    HStack { Spacer(); HBGhostButton("Ir al chat →") {} }
+                    HStack { Spacer(); HBGhostButton("Ir al chat →") { onGoToChat?() } }
                 }
             }
         }

--- a/habitOS-mobile/Views/MealPlanView.swift
+++ b/habitOS-mobile/Views/MealPlanView.swift
@@ -133,9 +133,15 @@ struct MealPlanView: View {
                 }
 
                 NavigationLink(destination: ShoppingListView()) {
-                    HBPrimaryButton("Lista de la compra", icon: "cart") {}
+                    HStack(spacing: 8) {
+                        Image(systemName: "cart").font(.system(size: 14, weight: .medium))
+                        Text("Lista de la compra").font(.system(size: 14, weight: .semibold))
+                    }
+                    .foregroundStyle(Color.hbVanilla)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 46)
+                    .background(Color.hbSage, in: RoundedRectangle(cornerRadius: HBTokens.radiusMedium))
                 }
-                .buttonStyle(.plain)
 
                 Spacer(minLength: 32)
             }

--- a/habitOS-mobile/Views/ProfileView.swift
+++ b/habitOS-mobile/Views/ProfileView.swift
@@ -85,9 +85,13 @@ struct ProfileView: View {
                             navRowLabel(icon: "brain.head.profile", label: "Memoria del coach")
                         }
                         HBDivider(indent: 44)
-                        navRow(icon: "lock.shield", label: "Privacidad")
+                        NavigationLink(destination: placeholderView(title: "Privacidad", icon: "lock.shield", body: "Tu información está protegida. HabitOS solo comparte datos con tu coach asignado y nunca con terceros.")) {
+                            navRowLabel(icon: "lock.shield", label: "Privacidad")
+                        }
                         HBDivider(indent: 44)
-                        navRow(icon: "questionmark.circle", label: "Ayuda")
+                        NavigationLink(destination: placeholderView(title: "Ayuda", icon: "questionmark.circle", body: "¿Necesitas ayuda? Escríbele a tu coach desde el chat. También puedes contactarnos en soporte@habitos.app.")) {
+                            navRowLabel(icon: "questionmark.circle", label: "Ayuda")
+                        }
                     }
                 }
                 .staggered(index: 3)
@@ -144,6 +148,27 @@ struct ProfileView: View {
             .padding(.top, 8)
         }
         .background(Color.hbVanilla)
+    }
+
+    private func placeholderView(title: String, icon: String, body: String) -> some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                Image(systemName: icon)
+                    .font(.system(size: 40))
+                    .foregroundStyle(Color.hbSage)
+                Text(body)
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color.hbMuted)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(4)
+                    .padding(.horizontal, 32)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 60)
+        }
+        .background(Color.hbVanilla)
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
     }
 
     private func statCard(_ label: String, value: String, unit: String) -> some View {

--- a/habitOS-mobile/Views/ProgressChartView.swift
+++ b/habitOS-mobile/Views/ProgressChartView.swift
@@ -4,8 +4,12 @@ import Charts
 struct ProgressChartView: View {
     let streaks: [StreakPoint]
     let weeklySummary: WeeklySummary?
+    var userId: UUID?
+    var startWeight: Double?
+    var goalWeight: Double?
 
     @State private var selectedTimeRange = 0
+    @State private var showWeightLog = false
     private let timeRanges = ["1S", "1M", "3M", "Todo"]
 
     var body: some View {
@@ -21,13 +25,22 @@ struct ProgressChartView: View {
                 }
                 adherenceChart.staggered(index: 2)
                 streakChart.staggered(index: 3)
-                HBPrimaryButton("Registrar peso", icon: "scalemass") {}.staggered(index: 4)
+                HBPrimaryButton("Registrar peso", icon: "scalemass") {
+                    if userId != nil { showWeightLog = true }
+                }.staggered(index: 4)
                 Spacer(minLength: 32)
             }
             .padding(.horizontal, HBTokens.padScreen)
             .padding(.top, 8)
         }
         .background(Color.hbVanilla)
+        .sheet(isPresented: $showWeightLog) {
+            if let uid = userId {
+                NavigationStack {
+                    WeightLogView(userId: uid, startWeight: startWeight, goalWeight: goalWeight)
+                }
+            }
+        }
     }
 
     private func weightCard(_ s: WeeklySummary) -> some View {


### PR DESCRIPTION
Rebased on current develop (post-PR#16 squash merge that brought HBT-001 through HBT-011 into develop).

Changes:
- SettingsViewModel: signOut always resets AppState
- ChatView: onSend callback, sendCurrentMessage, auto-scroll
- ContentView: onGoToChat/onGoToDiet, demo chat auto-reply with CoachMessage
- DashboardHomeView: wire Ver receta/Ya comi/Ir al chat buttons
- MealPlanView: fix nested Button in NavigationLink
- ProfileView: Privacidad/Ayuda with placeholder content
- ProgressChartView: Registrar peso opens WeightLogView

Supersedes #18