### PR TITLE
[HBT-016] Register stability backlog and bootstrap iOS CI

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,0 +1,105 @@
+name: iOS CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - '.github/workflows/ios-ci.yml'
+      - 'habitOS-mobile.xcodeproj/**'
+      - 'habitOS-mobile/**/*.swift'
+      - 'habitOS-mobile/**/*.plist'
+      - 'HabitOSWidget/**/*.swift'
+      - 'HabitOSWidget/**/*.plist'
+  push:
+    branches:
+      - develop
+    paths:
+      - '.github/workflows/ios-ci.yml'
+      - 'habitOS-mobile.xcodeproj/**'
+      - 'habitOS-mobile/**/*.swift'
+      - 'habitOS-mobile/**/*.plist'
+      - 'HabitOSWidget/**/*.swift'
+      - 'HabitOSWidget/**/*.plist'
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-ios-project:
+    name: Validate iOS project structure and build
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    env:
+      PROJECT_PATH: habitOS-mobile.xcodeproj
+      APP_TARGET: habitOS-mobile
+      TEST_TARGET: habitOS-mobileTests
+      WIDGET_TARGET: HabitOSWidgetExtension
+      XCODE_PATH: /Applications/Xcode_26.2.app
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Select Xcode 26.2
+        run: sudo xcode-select -switch "$XCODE_PATH"
+
+      - name: Show Xcode version
+        run: |
+          xcode-select -p
+          xcodebuild -version
+
+      - name: Inspect project
+        run: |
+          xcodebuild -list -project "$PROJECT_PATH"
+
+      - name: Build app target for iOS Simulator
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project "$PROJECT_PATH" \
+            -target "$APP_TARGET" \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            build | xcbeautify
+
+      - name: Build unit-test target for iOS Simulator
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project "$PROJECT_PATH" \
+            -target "$TEST_TARGET" \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            build | xcbeautify
+
+      - name: Build widget target for iOS Simulator
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project "$PROJECT_PATH" \
+            -target "$WIDGET_TARGET" \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            build | xcbeautify
+
+      - name: Report current CI limits
+        run: |
+          {
+            echo '## iOS CI bootstrap'
+            echo
+            echo '- Project inspection and simulator builds are now automated on GitHub Actions.'
+            echo '- Unit tests are not executed yet because no shared .xcscheme is versioned in the repository.'
+            echo '- Next CI step: add a shared scheme and promote build-only validation to test execution.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/HABITOS_EXECUTION_LEDGER.md
+++ b/HABITOS_EXECUTION_LEDGER.md
@@ -1,6 +1,6 @@
 # HabitOS Execution Ledger
 
-Last updated: 2026-03-08 06:00:00 CET
+Last updated: 2026-03-08 19:45:00 CET
 
 ## Purpose
 
@@ -51,10 +51,16 @@ Every Copilot or AI agent working in this repository must use this file as the s
 | HBT-009 | DONE | High | Project Governance | Create persistent Copilot operating rules, configuration guidance, and a mandatory execution ledger for future sessions. | 2026-03-07 18:33:46 CET | 2026-03-07 18:36:50 CET | Created `HABITOS_EXECUTION_LEDGER.md`, `.github/copilot-instructions.md`, `COPILOT_SETUP_HABITOS.md`, and updated `HABITOS_PROJECT_INTELLIGENCE_REPORT.html`. |
 | HBT-010 | DONE | High | Project Governance | Create a direct handoff document for the next Copilot and require future agents to keep the handoff/context documents updated so switching agents stays seamless. | 2026-03-07 18:43:22 CET | 2026-03-07 18:44:14 CET | Created `NEXT_COPILOT_HANDOFF.md` and updated `.github/copilot-instructions.md`, `COPILOT_SETUP_HABITOS.md`, and `HABITOS_PROJECT_INTELLIGENCE_REPORT.html` so future agents keep the shared context current. |
 | HBT-012 | DONE | High | UI Wiring | Wire all dead/placeholder UI buttons across the app: chat send, FAB actions, dashboard shortcuts, shopping list, profile nav, progress weight log. | 2026-03-08 05:00:00 CET | 2026-03-08 06:00:00 CET | Fixed SettingsViewModel logout (always resets AppState). ChatView: onSend callback + sendCurrentMessage + auto-scroll. ContentView: onGoToChat/onGoToDiet + demo chat auto-reply using CoachMessage. DashboardHomeView: Ver receta→diet, Ya comí→MealLogView, Ir al chat→chat tab. MealPlanView: fixed nested Button in NavigationLink. ProfileView: Privacidad/Ayuda as NavigationLinks. ProgressChartView: Registrar peso→WeightLogView. PR #19 merged to develop. |
+| HBT-013 | TODO | High | Dashboard UX | Remove the false dashboard error state when repository fetches partially fail but the fallback/demo content is still usable. | 2026-03-08 19:30:00 CET |  | Diagnose which repository calls should degrade gracefully, avoid surfacing blocking alerts after successful fallback hydration, and preserve observability for real failures. |
+| HBT-014 | TODO | High | Chat UX | Fix chat text-entry usability: dismiss keyboard reliably, avoid trapping navigation, and reduce excessive bottom spacing above the tab bar. | 2026-03-08 19:30:00 CET |  | Add proper focus management / dismissal affordances in `ChatView` and remove the oversized fixed bottom inset in `ContentView` so chat sits one tab-bar height above the menu instead of multiple stacked gaps. |
+| HBT-015 | TODO | Medium | Profile UX | Enable changing the profile avatar instead of showing a static placeholder circle only. | 2026-03-08 19:30:00 CET |  | Add a bounded avatar-edit flow backed by `app_users.avatar_url` and update the profile header so the user can change their image without introducing wider profile-edit scope. |
+| HBT-016 | DONE | Medium | CI/CD | Bootstrap GitHub Actions validation for the iOS app and keep the stability backlog visible for the next execution pass. | 2026-03-08 19:30:00 CET | 2026-03-08 19:45:00 CET | Issue #20 opened. Added `.github/workflows/ios-ci.yml` with GitHub Actions bootstrap on `macos-15`, explicit Xcode 26.2 selection, project inspection, and simulator builds for app, tests target, and widget target without code signing. Current limitation documented: test execution still depends on adding a shared `.xcscheme` to the repo. |
 
 ## Session Change Log
 
 Use this section to append one flat entry per completed task. Newest entries first.
+
+- 2026-03-08 19:45:00 CET | HBT-016 | Added first GitHub Actions workflow for iOS validation on macOS runners. The workflow now checks out the repo, selects Xcode 26.2, runs `xcodebuild -list`, and builds app/test/widget targets for `iphonesimulator` with `CODE_SIGNING_ALLOWED=NO`. Also registered the new stability backlog (HBT-013/014/015). | Files: `.github/workflows/ios-ci.yml`, `HABITOS_EXECUTION_LEDGER.md`
 
 - 2026-03-08 06:00:00 CET | HBT-012 | Wired all dead UI buttons on converged architecture. SettingsViewModel logout fix. ChatView onSend + sendCurrentMessage + auto-scroll. ContentView demo chat auto-reply with CoachMessage. DashboardHomeView: Ver receta→diet, Ya comí→MealLogView, Ir al chat→chat. MealPlanView nested Button fix. ProfileView Privacidad/Ayuda as NavigationLinks. ProgressChartView Registrar peso→WeightLogView sheet. | Files: `ContentView.swift`, `SettingsViewModel.swift`, `ChatView.swift`, `DashboardHomeView.swift`, `MealPlanView.swift`, `ProfileView.swift`, `ProgressChartView.swift`
 - 2026-03-08 05:45:00 CET | PR-CONSOLIDATION | Discovered PR #16 squash merge had brought ALL HBT-001-011 work into develop (branches were stacked). Closed 6 obsolete PRs (#4,#6,#8,#10,#12,#14). Rebased HBT-012 onto new develop. Created PR #19, merged. Zero open PRs remain. | PRs closed: #4,#6,#8,#10,#12,#14,#18. PR merged: #19.

--- a/NEXT_COPILOT_HANDOFF.md
+++ b/NEXT_COPILOT_HANDOFF.md
@@ -99,23 +99,28 @@ At the time of this handoff (2026-03-08), ALL backlog tasks are DONE and merged 
 
 Zero open PRs remain. All work is unified on develop.
 
-The likely next-value areas are:
+The immediate next-value areas are now bug-fix and stability only:
 
-- **Supabase dashboard config** — Add `habitos://auth-callback` as allowed redirect URL (manual step)
-- **CI/CD** — Add GitHub Actions workflow for build + test execution
-- **Remote photo storage** — Create `SupabasePhotoStorageRepository` when `body-photos` bucket is provisioned
-- **ShoppingRepository implementation** — Protocol exists but no Supabase implementation
-- **App Group + widget data** — Widget shows placeholder until shared data layer is implemented
-- **Real chat integration** — Replace demo auto-reply in ContentView with ChatViewModel + Supabase real-time
-- **Time period filtering** — ProgressChartView time range buttons animate but do not filter data yet
+- **HBT-013 Dashboard false error** — `DashboardViewModel.loadDashboard()` currently raises `"No pudimos cargar tu dashboard"` on partial repository failure even after loading usable fallback/demo data. Next pass should degrade gracefully without blocking alert spam.
+- **HBT-014 Chat keyboard + spacing** — `ChatView` lacks focus dismissal / keyboard escape routes, which can trap navigation, and `ContentView` still applies a blunt `safeAreaInset(height: 90)` that creates excessive bottom spacing in chat.
+- **HBT-015 Avatar editing** — `ProfileView` still renders a static initials circle; there is no bounded path to update `app_users.avatar_url` yet.
+- **Supabase dashboard config** — Add `habitos://auth-callback` as allowed redirect URL (manual step).
+
+Secondary follow-ups after the bug pass:
+
+- **Shared scheme for tests** — CI is bootstrapped, but full test execution still needs a versioned shared `.xcscheme`.
+- **Remote photo storage** — Create `SupabasePhotoStorageRepository` when `body-photos` bucket is provisioned.
+- **ShoppingRepository implementation** — Protocol exists but no Supabase implementation.
+- **App Group + widget data** — Widget shows placeholder until shared data layer is implemented.
+- **Time period filtering** — `ProgressChartView` time range buttons animate but do not filter data yet.
 
 ## Git Branch State
 
-All work is on develop. NEVER merge to main.
+Active working branch for the next pass may differ, but `develop` contains all merged product work through HBT-016. NEVER merge to main.
 
-Zero open PRs. The develop branch contains all HBT-001 through HBT-012 work.
+Zero open PRs at the moment this handoff was updated. `develop` contains all HBT-001 through HBT-016 work.
 
-Note: PR #16 (SQL migrations) was a squash merge that included all stacked commits from HBT-001 through HBT-011. PRs #4, #6, #8, #10, #12, #14 were closed as their changes were already included. HBT-012 was rebased onto the new develop and merged via PR #19.
+Note: PR #16 (SQL migrations) was a squash merge that included all stacked commits from HBT-001 through HBT-011. PRs #4, #6, #8, #10, #12, #14 were closed as their changes were already included. HBT-012 was rebased onto the new develop and merged via PR #19. HBT-016 then added `.github/workflows/ios-ci.yml`, which performs GitHub Actions bootstrap validation with explicit Xcode 26.2 selection and simulator builds, but still does not run tests because no shared scheme is versioned in the repo.
 
 ## Final Requirement
 


### PR DESCRIPTION
Closes #20

This PR does two things without adding new product features:

- registers the next non-feature backlog discovered during analysis
  - HBT-013 false dashboard error alert after fallback hydration
  - HBT-014 chat keyboard dismissal / navigation trap / oversized bottom gap
  - HBT-015 avatar editing path
- bootstraps GitHub Actions CI for the iOS project
  - macOS 15 runner
  - explicit Xcode 26.2 selection
  - xcodebuild project inspection
  - simulator builds for app, tests target, and widget target with CODE_SIGNING_ALLOWED=NO
  - documents the current limitation: no shared .xcscheme is versioned yet, so CI is build-only for now
